### PR TITLE
[FEAT] : #12 TMI 입력 및 방 입장 API

### DIFF
--- a/src/main/java/org/sopt/sopkathonweb1/common/dto/ErrorMessage.java
+++ b/src/main/java/org/sopt/sopkathonweb1/common/dto/ErrorMessage.java
@@ -8,11 +8,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ErrorMessage {
 
-    // message 사용 예시
-    // MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "ID에 해당하는 사용자가 존재하지 않습니다."),
-    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "요청하신 사용자가 존재하지 않습니다.")
-
-
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "요청하신 사용자가 존재하지 않습니다."),
+    ROOM_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "입력하신 방 코드와 일치하는 방이 존재하지 않습니다.")
     ;
     private final int status;
 

--- a/src/main/java/org/sopt/sopkathonweb1/controller/RoomController.java
+++ b/src/main/java/org/sopt/sopkathonweb1/controller/RoomController.java
@@ -3,17 +3,13 @@ package org.sopt.sopkathonweb1.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.sopkathonweb1.common.dto.SuccessMessage;
-import org.sopt.sopkathonweb1.common.dto.SuccessStatusResponse;
 import org.sopt.sopkathonweb1.controller.dto.BaseApiResponse;
 import org.sopt.sopkathonweb1.controller.dto.BaseApiResponseNonData;
 import org.sopt.sopkathonweb1.domain.Member;
 import org.sopt.sopkathonweb1.dto.request.RoomCreateRequest;
 import org.sopt.sopkathonweb1.dto.request.UserEnterRequest;
-import org.sopt.sopkathonweb1.dto.response.UserTmiResponse;
 import org.sopt.sopkathonweb1.service.RoomService;
 import org.sopt.sopkathonweb1.service.UserService;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -30,9 +26,9 @@ public class RoomController {
     private final UserService userService;
 
     @PostMapping("/create")
-    public BaseApiResponse createRoom(@RequestBody RoomCreateRequest request) {
+    public BaseApiResponseNonData createRoom(@RequestBody RoomCreateRequest request) {
         roomService.createRoom(request);
-        return new BaseApiResponse<>("방 생성 완료", null);
+        return new BaseApiResponseNonData("방 생성 완료");
     }
 
     @PostMapping("/{roomId}/enter")

--- a/src/main/java/org/sopt/sopkathonweb1/domain/Member.java
+++ b/src/main/java/org/sopt/sopkathonweb1/domain/Member.java
@@ -1,10 +1,6 @@
 package org.sopt.sopkathonweb1.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,8 +14,9 @@ public class Member {
     @Column(name = "member_id")
     private Long id;
 
-    @Column(name = "room_id")
-    private Long roomId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id")
+    private Room room;
 
     private String name;
 
@@ -27,13 +24,15 @@ public class Member {
     private String content;
 
     @Builder
-    public Member(String name, String content) {
+    public Member(Room room, String name, String content) {
         /*this.userId = userId;*/
+        this.room = room;
         this.name = name;
         this.content = content;
     }
 
-    public static Member create( String name, String content) {
-        return new Member( name, content);
+    public static Member create(Room room, String name, String content) {
+
+        return new Member(room, name, content);
     }
 }

--- a/src/main/java/org/sopt/sopkathonweb1/domain/Room.java
+++ b/src/main/java/org/sopt/sopkathonweb1/domain/Room.java
@@ -23,12 +23,18 @@ public class Room extends BaseTimeEntity{
     @Column(name = "room_id")
     private Long id;
 
+    // 방 입장 코드
+    private int code;
+
     // 해당 방의 인원 수
     private int peopleCount;
 
 
     @Builder
-    public Room(int peopleCount) {
+    public Room(
+            int code, int peopleCount
+    ) {
+        this.code = code;
         this.peopleCount = peopleCount;
     }
 

--- a/src/main/java/org/sopt/sopkathonweb1/dto/request/RoomCreateRequest.java
+++ b/src/main/java/org/sopt/sopkathonweb1/dto/request/RoomCreateRequest.java
@@ -1,6 +1,7 @@
 package org.sopt.sopkathonweb1.dto.request;
 
 public record RoomCreateRequest (
+        int code,
     int peopleCount
 ) {
 

--- a/src/main/java/org/sopt/sopkathonweb1/dto/request/UserEnterRequest.java
+++ b/src/main/java/org/sopt/sopkathonweb1/dto/request/UserEnterRequest.java
@@ -1,8 +1,10 @@
 package org.sopt.sopkathonweb1.dto.request;
 
 public record UserEnterRequest(
-    String name,
-    String content
+        int code,
+        String name,
+        String content
+
 ) {
 
 }

--- a/src/main/java/org/sopt/sopkathonweb1/repository/RoomRepository.java
+++ b/src/main/java/org/sopt/sopkathonweb1/repository/RoomRepository.java
@@ -2,10 +2,16 @@ package org.sopt.sopkathonweb1.repository;
 
 import org.sopt.sopkathonweb1.domain.Room;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface RoomRepository extends JpaRepository<Room, Long> {
+    @Query("SELECT r FROM Room r WHERE r.id = :roomId AND r.code = :code")
+    Optional<Room> findRoomByIdAndCode(@Param("roomId") Long roomId, @Param("code") int code);
 
+    @Query("SELECT COUNT(m) FROM Member m WHERE m.room.id = :roomId")
+    int countMembersByRoomId(@Param("roomId") Long roomId);
 }
 

--- a/src/main/java/org/sopt/sopkathonweb1/service/RoomService.java
+++ b/src/main/java/org/sopt/sopkathonweb1/service/RoomService.java
@@ -5,13 +5,14 @@ import org.sopt.sopkathonweb1.domain.Room;
 import org.sopt.sopkathonweb1.domain.Member;
 import org.sopt.sopkathonweb1.dto.request.RoomCreateRequest;
 import org.sopt.sopkathonweb1.dto.request.UserEnterRequest;
-import org.sopt.sopkathonweb1.dto.response.UserTmiResponse;
-import org.sopt.sopkathonweb1.exception.NotFoundException;
 import org.sopt.sopkathonweb1.repository.RoomRepository;
 import org.sopt.sopkathonweb1.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 @Service
 @RequiredArgsConstructor
@@ -19,42 +20,37 @@ public class RoomService {
     private final RoomRepository roomRepository;
     private final UserRepository userRepository;
 
-   /* public Member findMemberById(Long memberId) {
-        Room room = roomRepository.findById(memberId).orElseThrow(
-            () -> new NotFoundException(ErrorMessage.MEMBER_NOT_FOUND)
-        );
-        return userRepository.findById(memberId).orElseThrow(
-            () -> new NotFoundException(ErrorMessage.MEMBER_NOT_FOUND)
-        );
-    }*/
-
     @Transactional
     public void createRoom(RoomCreateRequest request) {
 
         Room room = roomRepository.save(
             Room.builder()
-                .peopleCount(request.peopleCount())
-                .build()
+                    .code(request.code())
+                    .peopleCount(request.peopleCount())
+                    .build()
         );
     }
 
     @Transactional
-    public void enterRoom(
-        UserEnterRequest request,
-        Long roomId
-    ) {
+    public ResponseEntity<?> enterRoom(UserEnterRequest request, Long roomId) {
+        Room room = roomRepository.findRoomByIdAndCode(roomId, request.code())
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND, ErrorMessage.ROOM_NOT_FOUND.getMessage()));
+
+        int currentMembers = roomRepository.countMembersByRoomId(roomId);
+        if (currentMembers >= room.getPeopleCount()) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body("Room is full");
+        }
 
         Member member = userRepository.save(
-            Member.builder()
-                .name(request.name())
-                .content(request.content())
-                .build()
+                Member.builder()
+                        .room(room)
+                        .name(request.name())
+                        .content(request.content())
+                        .build()
         );
 
+        return ResponseEntity.ok().build();
     }
-
-
-
-
 
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호
- Closes #12   

## Key Changes 🔑
TMI 입력 및 방 입장 API에서 방 입장 코드에 따른 roomId를 할당하는 기능을 추가했습니다.

## To Reviewers 📢
현재 제대로 동작하는 기능은 다음과 같습니다.

- 방 입장 code 비교 및 그에 따른 roomId 할당

https://github.com/NOW-SOPT-SOPKATHON-WEB1/SERVER/blob/5f85ec8c4121f684d8d1ce1c7996399c195cfea2/src/main/java/org/sopt/sopkathonweb1/repository/RoomRepository.java#L10-L12

- 설정된 인원을 초과하는 요청이 전달될 경우, 저장하지 않음

https://github.com/NOW-SOPT-SOPKATHON-WEB1/SERVER/blob/5f85ec8c4121f684d8d1ce1c7996399c195cfea2/src/main/java/org/sopt/sopkathonweb1/service/RoomService.java#L34-L43

📌 수정해야하는 문제점은 다음과 같습니다.

- 인원을 초과하는 경우 새로 요청되는 멤버 데이터가 저장되지 않는 것은 연동된 Database를 통해 확인하였으나, 요청 시에 계속 success 메시지가 반환되는 것

https://github.com/NOW-SOPT-SOPKATHON-WEB1/SERVER/blob/5f85ec8c4121f684d8d1ce1c7996399c195cfea2/src/main/java/org/sopt/sopkathonweb1/service/RoomService.java#L34-L43

위 코드를 보완해야할 것 같습니다.

- ErrorMessage가 적용되지 않음
전체적으로 ErrorMessage가 적절하게 적용되지 않고 있기 때문에 이 부분을 보완하여 각 Error 상황에 따른 ErrorMessage가 출력되도록 수정해야할 것 같습니다.


----------

회고 전에 배포하고 싶어서 시작했는데, 생각보다 고려하거나 수정해야하는 부분이 많아서 이 정도로 수정하고 마무리했습니다...
아쉽지만 일단 여기서 마무리하고 회고를 하는 걸로...😭

